### PR TITLE
Fixed tests on windows not finding the TCP connection

### DIFF
--- a/tests/Shared/SurrealInstance.cs
+++ b/tests/Shared/SurrealInstance.cs
@@ -22,8 +22,10 @@ public static class SurrealInstance {
 
     private static Process? Instantiate(string path) {
         ProcessStartInfo pi = new() {
-            CreateNoWindow = true,
-            UseShellExecute = false,
+            // These two settings can make the tests run twice as fast, but makes it harder to kill rouge DB instances
+            //CreateNoWindow = true,
+            //UseShellExecute = false,
+            UseShellExecute = true,
             FileName = path,
             Arguments = $"start memory -b {TestHelper.Loopback}:{TestHelper.Port} -u {TestHelper.User} -p {TestHelper.Pass} --log debug",
             WorkingDirectory = Environment.CurrentDirectory

--- a/tests/Shared/SurrealInstance.cs
+++ b/tests/Shared/SurrealInstance.cs
@@ -3,7 +3,7 @@ namespace SurrealDB.Shared.Tests;
 public static class SurrealInstance {
     public static Process Create() {
         // Wait until port is closed
-        TcpHelper.SpinUntilClosed($"0.0.0.0:{TestHelper.Port}");
+        TcpHelper.SpinUntilClosed($"{TestHelper.Loopback}:{TestHelper.Port}");
         // We have a race condition between when the SurrealDB socket opens (or closes), and when it accepts connections.
         // 50ms should be enough to run the tests on most devices.
         // Thread.Sleep(50);
@@ -14,7 +14,7 @@ public static class SurrealInstance {
         // Start new instances
         var p = Instantiate(path!);
         Debug.Assert(p is not null);
-        TcpHelper.SpinUntilListening($"0.0.0.0:{TestHelper.Port}");
+        TcpHelper.SpinUntilListening($"{TestHelper.Loopback}:{TestHelper.Port}");
         // Thread.Sleep(50);
         Debug.Assert(!p.HasExited);
         return p;
@@ -22,9 +22,10 @@ public static class SurrealInstance {
 
     private static Process? Instantiate(string path) {
         ProcessStartInfo pi = new() {
-            UseShellExecute = true,
+            CreateNoWindow = true,
+            UseShellExecute = false,
             FileName = path,
-            Arguments = $"start memory -b 0.0.0.0:{TestHelper.Port} -u {TestHelper.User} -p {TestHelper.Pass} --log debug",
+            Arguments = $"start memory -b {TestHelper.Loopback}:{TestHelper.Port} -u {TestHelper.User} -p {TestHelper.Pass} --log debug",
             WorkingDirectory = Environment.CurrentDirectory
         };
         return Process.Start(pi);


### PR DESCRIPTION
Tweaked a few things to make tests work on windows.

There is an issue though if you kill the tests partway though debugging as they are never disposed off. If we can figure out how to always dispose of the DB Instance then we can roughly double the testing speed.