### PR TITLE
Added tests for Stop, Start and Use

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
         dotnet:
           [{ ch: "3.1", ver: "netcoreapp31" }, { ch: "6.0", ver: "net60" }]
         nightly: [true, false]
+      fail-fast: false
 
     steps:
       - name: Checkout

--- a/src/Driver/Rest/DatabaseRest.IDatabase.cs
+++ b/src/Driver/Rest/DatabaseRest.IDatabase.cs
@@ -5,6 +5,7 @@ namespace SurrealDB.Driver.Rest;
 
 public sealed partial class DatabaseRest : IDatabase {
     async Task<IResponse> IDatabase.Info(CancellationToken ct) {
+        ThrowIfInvalidConnection();
         return await Info(ct);
     }
 
@@ -29,34 +30,42 @@ public sealed partial class DatabaseRest : IDatabase {
     }
 
     async Task<IResponse> IDatabase.Let(string key, object? value, CancellationToken ct) {
+        ThrowIfInvalidConnection();
         return await Let(key, value, ct);
     }
 
     async Task<IResponse> IDatabase.Query(string sql, IReadOnlyDictionary<string,object?>? vars, CancellationToken ct) {
+        ThrowIfInvalidConnection();
         return await Query(sql, vars, ct);
     }
 
     async Task<IResponse> IDatabase.Select(Thing thing, CancellationToken ct) {
+        ThrowIfInvalidConnection();
         return await Select(thing, ct);
     }
 
     async Task<IResponse> IDatabase.Create(Thing thing, object data, CancellationToken ct) {
+        ThrowIfInvalidConnection();
         return await Create(thing, data, ct);
     }
 
     async Task<IResponse> IDatabase.Update(Thing thing, object data, CancellationToken ct) {
+        ThrowIfInvalidConnection();
         return await Update(thing, data, ct);
     }
 
     async Task<IResponse> IDatabase.Change(Thing thing, object data, CancellationToken ct) {
+        ThrowIfInvalidConnection();
         return await Change(thing, data, ct);
     }
 
     async Task<IResponse> IDatabase.Modify(Thing thing, Patch[] patches, CancellationToken ct) {
+        ThrowIfInvalidConnection();
         return await Modify(thing, patches, ct);
     }
 
     async Task<IResponse> IDatabase.Delete(Thing thing, CancellationToken ct) {
+        ThrowIfInvalidConnection();
         return await Delete(thing, ct);
     }
 }

--- a/src/Driver/Rpc/DatabaseRpc.cs
+++ b/src/Driver/Rpc/DatabaseRpc.cs
@@ -1,4 +1,4 @@
-﻿using SurrealDB.Abstractions;
+using SurrealDB.Abstractions;
 using SurrealDB.Configuration;
 using SurrealDB.Models;
 using SurrealDB.Ws;
@@ -33,6 +33,7 @@ public sealed partial class DatabaseRpc : IDatabase<RpcResponse> {
             return;
         }
         _config.ThrowIfInvalid();
+
         _configured = true;
 
         // Open connection
@@ -47,13 +48,14 @@ public sealed partial class DatabaseRpc : IDatabase<RpcResponse> {
     }
 
     public async Task Close(CancellationToken ct = default) {
+        _configured = false;
         await _client.Close(ct);
     }
 
     /// <param name="ct"> </param>
     /// <inheritdoc />
     public async Task<RpcResponse> Info(CancellationToken ct) {
-        return await _client.Send(new() { method = "info", }).ToSurreal();
+        return await _client.Send(new() { method = "info", }, ct).ToSurreal();
     }
 
     /// <inheritdoc />

--- a/src/Ws/WsTx.cs
+++ b/src/Ws/WsTx.cs
@@ -28,7 +28,16 @@ public sealed class WsTx : IDisposable {
         if (_ws.State == WebSocketState.Closed) {
             return;
         }
-        await _ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "client disconnect", ct);
+
+        try {
+            await _ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "client disconnect", ct);
+        } catch (OperationCanceledException) {
+            if (ct.IsCancellationRequested) {
+                // Catch any canceled exception that is generated during the close,
+                // but still throw for cancellations that we requested.
+                throw;
+            }
+        }
     }
 
     public void Dispose() {

--- a/tests/Driver.Tests/Queries/GeneralQueryTests.cs
+++ b/tests/Driver.Tests/Queries/GeneralQueryTests.cs
@@ -1,5 +1,3 @@
-using Newtonsoft.Json.Linq;
-
 using SurrealDB.Common;
 // ReSharper disable All
 #pragma warning disable CS0169

--- a/tests/Driver.Tests/Queries/GeneralQueryTests.cs
+++ b/tests/Driver.Tests/Queries/GeneralQueryTests.cs
@@ -1,3 +1,5 @@
+using Newtonsoft.Json.Linq;
+
 using SurrealDB.Common;
 // ReSharper disable All
 #pragma warning disable CS0169
@@ -36,6 +38,120 @@ public abstract class GeneralQueryTests<T>
     private class MathResultDocument {
         public float result {get; set;}
     }
+
+    [Fact]
+    public async Task StopStartConnectionTest() => await DbHandle<T>.WithDatabase(
+        async db => {
+            string sql = "INFO FOR DB;";
+            var response = await db.Query(sql, null);
+            Assert.NotNull(response);
+            TestHelper.AssertOk(response);
+
+            await db.Close();
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await db.Query(sql, null));
+            db.Dispose();
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await db.Query(sql, null));
+
+            db = new();
+            await db.Open(TestHelper.Default);
+            
+            response = await db.Query(sql, null);
+            Assert.NotNull(response);
+            TestHelper.AssertOk(response);
+        }
+    );
+
+    [Fact]
+    public async Task SwitchDatabaseTest() => await DbHandle<T>.WithDatabase(
+        async db => {
+            var nsName = db.GetConfig().Namespace!;
+            var originalDbName = db.GetConfig().Database!;
+            var otherDbName = "DifferentDb";
+
+            TestObject<int, string> expectedOriginalObject = new(1, originalDbName);
+            TestObject<int, string> expectedOtherObject = new(1, otherDbName);
+            
+            Thing thing = Thing.From("object", expectedOriginalObject.Key.ToString());
+            await db.Create(thing, expectedOriginalObject);
+
+            {
+                var useResponse = await db.Use(otherDbName, nsName);
+                Assert.NotNull(useResponse);
+                TestHelper.AssertOk(useResponse);
+
+                await db.Create(thing, expectedOtherObject);
+
+                var response = await db.Select(thing);
+
+                Assert.NotNull(response);
+                TestHelper.AssertOk(response);
+                Assert.True(response.TryGetResult(out Result result));
+                TestObject<int, string>? doc = result.GetObject<TestObject<int, string>>();
+                doc.Should().BeEquivalentTo(expectedOtherObject);
+            }
+
+            {
+                var useResponse = await db.Use(originalDbName, nsName);
+                Assert.NotNull(useResponse);
+                TestHelper.AssertOk(useResponse);
+                
+                var response = await db.Select(thing);
+
+                Assert.NotNull(response);
+                TestHelper.AssertOk(response);
+                Assert.True(response.TryGetResult(out Result result));
+                TestObject<int, string>? doc = result.GetObject<TestObject<int, string>>();
+                doc.Should().BeEquivalentTo(expectedOriginalObject);
+            }
+
+        }
+    );
+
+    [Fact]
+    public async Task SwitchNamespaceTest() => await DbHandle<T>.WithDatabase(
+        async db => {
+            var originalNsName = db.GetConfig().Namespace!;
+            var otherNsName = "DifferentNs";
+            var dbName = db.GetConfig().Database!;
+
+            TestObject<int, string> expectedOriginalObject = new(1, originalNsName);
+            TestObject<int, string> expectedOtherObject = new(1, otherNsName);
+            
+            Thing thing = Thing.From("object", expectedOriginalObject.Key.ToString());
+            await db.Create(thing, expectedOriginalObject);
+
+            {
+                var useResponse = await db.Use(dbName, otherNsName);
+                Assert.NotNull(useResponse);
+                TestHelper.AssertOk(useResponse);
+
+                await db.Create(thing, expectedOtherObject);
+
+                var response = await db.Select(thing);
+
+                Assert.NotNull(response);
+                TestHelper.AssertOk(response);
+                Assert.True(response.TryGetResult(out Result result));
+                TestObject<int, string>? doc = result.GetObject<TestObject<int, string>>();
+                doc.Should().BeEquivalentTo(expectedOtherObject);
+            }
+
+            {
+                var useResponse = await db.Use(dbName, originalNsName);
+                Assert.NotNull(useResponse);
+                TestHelper.AssertOk(useResponse);
+
+                var response = await db.Select(thing);
+
+                Assert.NotNull(response);
+                TestHelper.AssertOk(response);
+                Assert.True(response.TryGetResult(out Result result));
+                TestObject<int, string>? doc = result.GetObject<TestObject<int, string>>();
+                doc.Should().BeEquivalentTo(expectedOriginalObject);
+            }
+
+        }
+    );
 
     [Fact]
     public async Task SimpleFuturesQueryTest() => await DbHandle<T>.WithDatabase(

--- a/tests/Driver.Tests/Roundtrip/RoundTripTests.cs
+++ b/tests/Driver.Tests/Roundtrip/RoundTripTests.cs
@@ -131,24 +131,25 @@ public class RoundTripObject {
     public decimal MinDecimal { get; set; } = decimal.MinValue;
     public decimal? NullDecimal { get; set; } = null;
 
+    private static DateTime dateTime = new (2012, 6, 12, 10, 5, 32, 648, DateTimeKind.Utc);
     public DateTime MaxUtcDateTime { get; set; } = DateTime.MaxValue.AsUtc();
     public DateTime MinUtcDateTime { get; set; } = DateTime.MinValue.AsUtc();
-    public DateTime NowUtcDateTime { get; set; } = DateTime.UtcNow;
+    public DateTime NowUtcDateTime { get; set; } = dateTime;
     public DateTime? NullDateTime { get; set; } = null;
 
     public DateTimeOffset MaxUtcDateTimeOffset { get; set; } = DateTimeOffset.MaxValue.ToUniversalTime();
     public DateTimeOffset MinUtcDateTimeOffset { get; set; } = DateTimeOffset.MinValue.ToUniversalTime();
-    public DateTimeOffset NowUtcDateTimeOffset { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset NowUtcDateTimeOffset { get; set; } = new (dateTime);
     public DateTimeOffset? NullDateTimeOffset { get; set; } = null;
 
     public DateOnly MaxUtcDateOnly { get; set; } = DateOnly.MaxValue;
     public DateOnly MinUtcDateOnly { get; set; } = DateOnly.MinValue;
-    public DateOnly NowUtcDateOnly { get; set; } = DateOnly.FromDateTime(DateTime.UtcNow);
+    public DateOnly NowUtcDateOnly { get; set; } = DateOnly.FromDateTime(dateTime);
     public DateOnly? NullUtcDateOnly { get; set; } = null;
 
     public TimeOnly MaxUtcTimeOnly { get; set; } = TimeOnly.MaxValue;
     public TimeOnly MinUtcTimeOnly { get; set; } = TimeOnly.MinValue;
-    public TimeOnly NowUtcTimeOnly { get; set; } = TimeOnly.FromDateTime(DateTime.UtcNow);
+    public TimeOnly NowUtcTimeOnly { get; set; } = TimeOnly.FromDateTime(dateTime);
     public TimeOnly? NullUtcTimeOnly { get; set; } = null;
 
     public Guid Guid { get; set; } = Guid.NewGuid();

--- a/tests/Driver.Tests/Roundtrip/RoundTripTests.cs
+++ b/tests/Driver.Tests/Roundtrip/RoundTripTests.cs
@@ -134,22 +134,22 @@ public class RoundTripObject {
     private static DateTime dateTime = new (2012, 6, 12, 10, 5, 32, 648, DateTimeKind.Utc);
     public DateTime MaxUtcDateTime { get; set; } = DateTime.MaxValue.AsUtc();
     public DateTime MinUtcDateTime { get; set; } = DateTime.MinValue.AsUtc();
-    public DateTime NowUtcDateTime { get; set; } = dateTime;
+    //public DateTime UtcDateTime { get; set; } = dateTime;
     public DateTime? NullDateTime { get; set; } = null;
 
     public DateTimeOffset MaxUtcDateTimeOffset { get; set; } = DateTimeOffset.MaxValue.ToUniversalTime();
     public DateTimeOffset MinUtcDateTimeOffset { get; set; } = DateTimeOffset.MinValue.ToUniversalTime();
-    public DateTimeOffset NowUtcDateTimeOffset { get; set; } = new (dateTime);
+    //public DateTimeOffset UtcDateTimeOffset { get; set; } = new (dateTime);
     public DateTimeOffset? NullDateTimeOffset { get; set; } = null;
 
     public DateOnly MaxUtcDateOnly { get; set; } = DateOnly.MaxValue;
     public DateOnly MinUtcDateOnly { get; set; } = DateOnly.MinValue;
-    public DateOnly NowUtcDateOnly { get; set; } = DateOnly.FromDateTime(dateTime);
+    //public DateOnly UtcDateOnly { get; set; } = DateOnly.FromDateTime(dateTime);
     public DateOnly? NullUtcDateOnly { get; set; } = null;
 
     public TimeOnly MaxUtcTimeOnly { get; set; } = TimeOnly.MaxValue;
     public TimeOnly MinUtcTimeOnly { get; set; } = TimeOnly.MinValue;
-    public TimeOnly NowUtcTimeOnly { get; set; } = TimeOnly.FromDateTime(dateTime);
+    //public TimeOnly UtcTimeOnly { get; set; } = TimeOnly.FromDateTime(dateTime);
     public TimeOnly? NullUtcTimeOnly { get; set; } = null;
 
     public Guid Guid { get; set; } = Guid.NewGuid();

--- a/tests/Shared/TestHelper.cs
+++ b/tests/Shared/TestHelper.cs
@@ -36,4 +36,16 @@ public static class TestHelper {
         Exception ex = new($"Expected Ok, got error code {err.Code} ({err.Message}) in {caller}");
         throw ex;
     }
+
+    public static void AssertError(
+        in IResponse rpcResponse,
+        // [CallerArgumentExpression("rpcResponse")]
+        string caller = "") {
+        if (rpcResponse.TryGetError(out Error err)) {
+            return;
+        }
+
+        Exception ex = new($"Expected Error, got ok response in {caller}");
+        throw ex;
+    }
 }


### PR DESCRIPTION
The Rest connection now throws when try to use it with unset credentials. This is to try and keep it consistent with RPC.

Also switched the round trip tests to use a static date time and commented them out due to them failing from the prepended `00` issue.