### PR TITLE
Added Relate and Graph Semantics tests

### DIFF
--- a/tests/Driver.Tests/Queries/QueryTests.cs
+++ b/tests/Driver.Tests/Queries/QueryTests.cs
@@ -229,7 +229,7 @@ public abstract class QueryTests<T, TKey, TValue>
             Thing thing2 = Thing.From("object2", expectedObject.Key!.ToString());
             await db.Create(thing2, expectedObject);
 
-            var relateSql = "RELATE $thing1->hasOtherThing->$thing2;";
+            var relateSql = "RELATE ($thing1)->hasOtherThing->($thing2)";
             var vars = new Dictionary<string, object>
             {
                 {"thing1", thing1},
@@ -239,13 +239,13 @@ public abstract class QueryTests<T, TKey, TValue>
             Assert.NotNull(relateResponse);
             TestHelper.AssertOk(relateResponse);
 
-            var thing2Sql = "SELECT * FROM object2 WHERE $thing1->hasOtherThing->object2.*";
+            var thing2Sql = "SELECT ->hasOtherThing->object2.* AS field FROM $thing1";
             var thing2Response = await db.Query(thing2Sql, vars);
             Assert.NotNull(thing2Response);
             TestHelper.AssertOk(thing2Response);
             Assert.True(thing2Response.TryGetResult(out Result thing2Result));
-            TestObject<TKey, TValue>? thing2Doc = thing2Result.GetObject<TestObject<TKey, TValue>>();
-            thing2Doc.Should().BeEquivalentTo(expectedObject);
+            Field<TestObject<TKey, TValue>>? thing2Doc = thing2Result.GetObject<Field<TestObject<TKey, TValue>>>();
+            thing2Doc.field.First().Should().BeEquivalentTo(expectedObject);
         }
     );
 

--- a/tests/Driver.Tests/Queries/QueryTests.cs
+++ b/tests/Driver.Tests/Queries/QueryTests.cs
@@ -217,6 +217,38 @@ public abstract class QueryTests<T, TKey, TValue>
         }
     );
 
+    [Theory]
+    [MemberData("KeyAndValuePairs")]
+    public async Task SimpleRelateAndGraphSemanticsQueryTest(TKey key, TValue value) => await DbHandle<T>.WithDatabase(
+        async db => {
+            TestObject<TKey, TValue> expectedObject = new(key, value);
+
+            Thing thing1 = Thing.From("object1", expectedObject.Key!.ToString());
+            await db.Create(thing1, expectedObject);
+
+            Thing thing2 = Thing.From("object2", expectedObject.Key!.ToString());
+            await db.Create(thing2, expectedObject);
+
+            var relateSql = "RELATE $thing1->hasOtherThing->$thing2;";
+            var vars = new Dictionary<string, object>
+            {
+                {"thing1", thing1},
+                {"thing2", thing2},
+            };
+            var relateResponse = await db.Query(relateSql, vars);
+            Assert.NotNull(relateResponse);
+            TestHelper.AssertOk(relateResponse);
+
+            var thing2Sql = "SELECT * FROM object2 WHERE $thing1->hasOtherThing->object2.*";
+            var thing2Response = await db.Query(thing2Sql, vars);
+            Assert.NotNull(thing2Response);
+            TestHelper.AssertOk(thing2Response);
+            Assert.True(thing2Response.TryGetResult(out Result thing2Result));
+            TestObject<TKey, TValue>? thing2Doc = thing2Result.GetObject<TestObject<TKey, TValue>>();
+            thing2Doc.Should().BeEquivalentTo(expectedObject);
+        }
+    );
+
     [DebuggerStepThrough]
     protected static string Serialize<V>(in V value) {
         return JsonSerializer.Serialize(value, SerializerOptions.Shared);

--- a/tests/Shared/TestObjects.cs
+++ b/tests/Shared/TestObjects.cs
@@ -22,7 +22,7 @@ public class ExtendedTestObject<TKey, TValue> : TestObject<TKey, TValue> {
     public TValue MergeValue { get; set; }
 }
 
-public record struct IdScopeAuth(
+public readonly record struct IdScopeAuth(
     string id,
     string user,
     string pass,
@@ -30,6 +30,16 @@ public record struct IdScopeAuth(
     string DB,
     string SC) : IAuth;
 
-public record struct User(
+public readonly record struct User(
     string id,
     string email);
+
+public class Temperature {
+    public string location;
+    public DateTime date;
+    public float temperature;
+}
+
+public class Field<T> {
+    public List<T> field { get; set; }
+}


### PR DESCRIPTION
Added a test for creating Relations and the querying them via Graph Semantics.

The RPC queries are failing while the REST ones pass.

The failing query `RELATE $thing1->hasOtherThing->$thing2;` produces the following JSON:
```
{
  "id": "qrBo3bkT",
  "method": "query",
  "params": [
    "RELATE $thing1->hasOtherThing->$thing2;",
    {
      "thing1": "object1:VbNy93UFUX",
      "thing2": "object2:VbNy93UFUX"
    }
  ]
}
```

Tweaking the query slightly to look like `RELATE $thing1 -> hasOtherThing -> $thing2;` or `RELATE ($thing1)->hasOtherThing->($thing2)` passes.
```
{
  "id": "n3pJe7ja",
  "method": "query",
  "params": [
    "RELATE $thing1 -> hasOtherThing -> $thing2;",
    {
      "thing1": "object1:7VWcpn9fO1",
      "thing2": "object2:7VWcpn9fO1"
    }
  ]
}
```

The two RPC documents looks functionally the same